### PR TITLE
package-lock.jsonはライブラリでは無いほうが良い

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
基本的にはバージョンを固定しないべき